### PR TITLE
Text Templating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,23 +30,18 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
 
-      - name: echo ref
-        run: echo ${{github.ref}}
-
-      - name: setup gradle with dependency graph
+      - name: Build with Gradle and generate dependency Graph
         if: ${{github.ref == 'refs/heads/main' && github.event_name != 'pull_request'}}
         uses: gradle/gradle-build-action@v2
-        # with:
-        #   dependency-graph: 'generate-and-submit'
+        with:
+          arguments: build
+          dependency-graph: 'generate-and-submit'
 
-      - name: setup gradle
+      - name: Build with Gradle
         if: ${{github.ref != 'refs/heads/main' || github.event_name == 'pull_request'}}
         uses: gradle/gradle-build-action@v2
-        # with:
-        #   dependency-graph: 'generate-and-upload'
-
-      - name: gradle clean build
-        run: ./gradlew clean build
+        with:
+          arguments: build
 
 #      - name: Capture Fabric Artifacts
 #        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS

--- a/common/src/main/kotlin/dev/erdragh/astralbot/commands/discord/CommandHandlingListener.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/commands/discord/CommandHandlingListener.kt
@@ -2,6 +2,7 @@ package dev.erdragh.astralbot.commands.discord
 
 import dev.erdragh.astralbot.LOGGER
 import dev.erdragh.astralbot.applicationId
+import dev.erdragh.astralbot.config.AstralBotTextConfig
 import dev.erdragh.astralbot.guild
 import dev.erdragh.astralbot.waitForSetup
 import net.dv8tion.jda.api.entities.Guild
@@ -61,14 +62,14 @@ object CommandHandlingListener : ListenerAdapter() {
     fun updateCommands(guild: Guild, sendMessage: (msg: String) -> Unit) {
         guild.retrieveCommands().submit().whenComplete { fetchedCommands, error ->
             if (error != null) {
-                sendMessage("Something went wrong: ${error.localizedMessage}")
+                sendMessage(AstralBotTextConfig.RELOAD_ERROR.get().replace("{{error}}", error.localizedMessage))
                 return@whenComplete
             }
             waitForSetup()
             val deletedCommands = fetchedCommands.filter { it.applicationIdLong == applicationId }.map { guild.deleteCommandById(it.id).submit() }
             deletedCommands.forEach { it.get() }
             guild.updateCommands().addCommands(getEnabledCommands().map { it.command }).queue {
-                sendMessage("Reloaded commands for guild")
+                sendMessage(AstralBotTextConfig.RELOAD_SUCCESS.get())
             }
         }
     }
@@ -84,7 +85,7 @@ object CommandHandlingListener : ListenerAdapter() {
         if (usedCommand != null) {
             usedCommand.handle(event)
         } else {
-            event.reply("Something went wrong").queue()
+            event.reply(AstralBotTextConfig.GENERIC_ERROR.get()).queue()
         }
     }
 

--- a/common/src/main/kotlin/dev/erdragh/astralbot/commands/discord/SetupCommands.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/commands/discord/SetupCommands.kt
@@ -2,6 +2,7 @@ package dev.erdragh.astralbot.commands.discord
 
 import dev.erdragh.astralbot.LOGGER
 import dev.erdragh.astralbot.config.AstralBotConfig
+import dev.erdragh.astralbot.config.AstralBotTextConfig
 import dev.erdragh.astralbot.guild
 import dev.erdragh.astralbot.handlers.WhitelistHandler
 import dev.erdragh.astralbot.textChannel
@@ -30,7 +31,7 @@ object ReloadCommand : HandledSlashCommand {
         event.deferReply(true).queue()
         val guild = event.guild
         if (guild == null) {
-            event.hook.setEphemeral(true).sendMessage("Failed to fetch Guild to refresh").queue()
+            event.hook.setEphemeral(true).sendMessage(AstralBotTextConfig.GENERIC_ERROR.get()).queue()
             return
         }
         CommandHandlingListener.updateCommands(guild) { msg ->
@@ -86,7 +87,7 @@ object ChatSyncCommand : HandledSlashCommand {
             success = true
         }
         event.hook.setEphemeral(true)
-            .sendMessage(if (success) "Successfully set up chat synchronization" else "Something went wrong while setting up chat sync")
+            .sendMessage(if (success) AstralBotTextConfig.GENERIC_SUCCESS.get() else AstralBotTextConfig.GENERIC_ERROR.get())
             .queue()
     }
 }
@@ -112,7 +113,7 @@ object LinkRoleCommand : HandledSlashCommand {
         event.deferReply(true).queue()
         val role = event.getOptionsByType(OptionType.ROLE).findLast { it.name == OPTION_ROLE }?.asRole
         if (role !is Role) {
-            event.hook.setEphemeral(true).sendMessage("Failed to resolve role from command option").queue()
+            event.hook.setEphemeral(true).sendMessage(AstralBotTextConfig.GENERIC_ERROR.get()).queue()
             LOGGER.error("Failed to resolve role from command option")
             return
         }
@@ -139,6 +140,6 @@ object LinkRoleCommand : HandledSlashCommand {
             }
         }
 
-        event.hook.setEphemeral(true).sendMessage("Set up role ${role.name} for linked members").queue()
+        event.hook.setEphemeral(true).sendMessage(AstralBotTextConfig.GENERIC_SUCCESS.get()).queue()
     }
 }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/commands/minecraft/MinecraftCommands.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/commands/minecraft/MinecraftCommands.kt
@@ -4,6 +4,7 @@ import com.mojang.brigadier.Command
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.builder.LiteralArgumentBuilder.literal
 import com.mojang.brigadier.context.CommandContext
+import dev.erdragh.astralbot.config.AstralBotTextConfig
 import dev.erdragh.astralbot.handlers.WhitelistHandler
 import net.minecraft.commands.CommandSourceStack
 import net.minecraft.network.chat.Component
@@ -15,10 +16,12 @@ fun registerMinecraftCommands(dispatcher: CommandDispatcher<CommandSourceStack>)
 object LinkCommand : Command<CommandSourceStack> {
     override fun run(context: CommandContext<CommandSourceStack>?): Int {
         val caller = context?.source?.playerOrException!!
+        if (WhitelistHandler.checkWhitelist(caller.uuid) != null) {
+            context.source.sendFailure(Component.literal(AstralBotTextConfig.LINK_COMMAND_ALREADY_LINKED.get()))
+        }
         val whitelistCode = WhitelistHandler.getOrGenerateWhitelistCode(caller.uuid)
         context.source.sendSuccess({
-            Component.literal("Use this code to /link yourself on Discord:")
-                .append(Component.literal("$whitelistCode").withStyle { it.withItalic(true) })
+            Component.literal(AstralBotTextConfig.LINK_COMMAND_MESSAGE.get().replace("{{code}}", "$whitelistCode"))
         }, false)
         return 0
     }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -1,0 +1,25 @@
+package dev.erdragh.astralbot.config
+
+import net.minecraftforge.common.ForgeConfigSpec
+
+object AstralBotTextConfig {
+    val SPEC: ForgeConfigSpec
+
+    val FAQ_ERROR: ForgeConfigSpec.ConfigValue<String>
+    val FAQ_NO_REGISTERED: ForgeConfigSpec.ConfigValue<String>
+
+    init {
+        val builder = ForgeConfigSpec.Builder()
+
+        FAQ_ERROR = builder.comment("Message sent to Discord if an error ocurrs during FAQ loading")
+            .define("faqError", "Bot Error (Contact Bot Operator)")
+        FAQ_NO_REGISTERED =
+            builder.comment(
+                """Message sent to Discord when there is no FAQ for the given id.
+                The placeholder {{id}} may be used to include the requested id""".trimMargin()
+            )
+                .define("faqNoRegistered", "No FAQ registered for id: `{{id}}`")
+
+        SPEC = builder.build()
+    }
+}

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -22,48 +22,50 @@ object AstralBotTextConfig {
 
     init {
         val builder = ForgeConfigSpec.Builder()
+        val whitespaceRegex = Regex("\n[ \t]+");
 
         GENERIC_ERROR = builder.comment("Generic error message sent to Discord")
             .define("genericError", "Something went wrong!")
 
         FAQ_ERROR = builder.comment("Message sent to Discord if an error ocurrs during FAQ loading")
-            .define("faqError", "Bot Error (Contact Bot Operator)")
+            .define(mutableListOf("faq", "error"), "Bot Error (Contact Bot Operator)")
         FAQ_NO_REGISTERED =
             builder.comment(
                 """Message sent to Discord when there is no FAQ for the given id.
-                The placeholder {{id}} may be used to include the requested id""".trimIndent()
+                The placeholder {{id}} may be used to include the requested id""".replace(whitespaceRegex, "\n")
             )
-                .define("faqNoRegistered", "No FAQ registered for id: `{{id}}`")
+                .define(mutableListOf("faq", "notRegistered"), "No FAQ registered for id: `{{id}}`")
 
         TICK_REPORT =
             builder.comment("""Template for the tick report sent to users on the /tps command.
                 the average time per tick in MSPT can be used via {{mspt}} and the TPS calculated
                 from it via {{tps}}
-            """.trimIndent())
+            """.replace(whitespaceRegex, "\n"))
                 .define("tickReport", "Average Tick Time: {{mspt}} MSPT (TPS: {{tps}})")
 
         PLAYER_MESSAGE =
             builder.comment("""Template for how Minecraft chat messages are sent to Discord.
                 The player's name can be accessed via {{name}} and its name with pre- and suffix
                 via {{fullName}}. The message itself is accessed via {{message}}.
-            """.trimIndent())
+            """.replace(whitespaceRegex, "\n"))
                 .define(mutableListOf("messages", "minecraft"), "<{{fullName}}> {{message}}")
 
         DISCORD_MESSAGE =
             builder.comment("""Template for how Discord messages are synchronized to Minecraft.
-                The sender is referenced by {{user}}. The optional response is accessed by {{reply}}
-            """.trimIndent())
-                .define(mutableListOf("messages", "discord", "message"), "{{user}}{{reply}}:")
+                The sender is referenced by {{user}}. The optional response is accessed by {{reply}}.
+                The message itself is accessed with {{message}}
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("messages", "discord", "message"), "{{user}}{{reply}}: {{message}}")
         DISCORD_REPLY =
             builder.comment("""Template for the {{reply}} part of the discordMessage.
                 The user the message is in reply to is referenced by {{replied}}
-            """.trimIndent())
-                .define(mutableListOf("messages", "discord", "reply"), " replying to {{replied}}:")
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("messages", "discord", "reply"), " replying to {{replied}}")
 
         RELOAD_ERROR =
             builder.comment("""Template for the error message sent to Discord when reloading fails.
                 The error message itself is accessible with {{error}}
-            """.trimIndent())
+            """.replace(whitespaceRegex, "\n"))
                 .define(mutableListOf("reload", "error"), "Something went wrong: {{error}}")
         RELOAD_SUCCESS = builder.comment("Message sent to Discord after a successful reload")
             .define(mutableListOf("reload", "success"), "Reloaded commands for guild")

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -6,6 +6,7 @@ object AstralBotTextConfig {
     val SPEC: ForgeConfigSpec
 
     val GENERIC_ERROR: ForgeConfigSpec.ConfigValue<String>
+    val GENERIC_SUCCESS: ForgeConfigSpec.ConfigValue<String>
 
     val FAQ_ERROR: ForgeConfigSpec.ConfigValue<String>
     val FAQ_NO_REGISTERED: ForgeConfigSpec.ConfigValue<String>
@@ -35,6 +36,8 @@ object AstralBotTextConfig {
 
         GENERIC_ERROR = builder.comment("Generic error message sent to Discord")
             .define("genericError", "Something went wrong!")
+        GENERIC_SUCCESS = builder.comment("Generic success message sent to Discord")
+            .define("genericSuccess", "Success!")
 
         FAQ_ERROR = builder.comment("Message sent to Discord if an error ocurrs during FAQ loading")
             .define(mutableListOf("faq", "error"), "Bot Error (Contact Bot Operator)")

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -5,6 +5,8 @@ import net.minecraftforge.common.ForgeConfigSpec
 object AstralBotTextConfig {
     val SPEC: ForgeConfigSpec
 
+    val GENERIC_ERROR: ForgeConfigSpec.ConfigValue<String>
+
     val FAQ_ERROR: ForgeConfigSpec.ConfigValue<String>
     val FAQ_NO_REGISTERED: ForgeConfigSpec.ConfigValue<String>
 
@@ -15,8 +17,14 @@ object AstralBotTextConfig {
     val DISCORD_MESSAGE: ForgeConfigSpec.ConfigValue<String>
     val DISCORD_REPLY: ForgeConfigSpec.ConfigValue<String>
 
+    val RELOAD_ERROR: ForgeConfigSpec.ConfigValue<String>
+    val RELOAD_SUCCESS: ForgeConfigSpec.ConfigValue<String>
+
     init {
         val builder = ForgeConfigSpec.Builder()
+
+        GENERIC_ERROR = builder.comment("Generic error message sent to Discord")
+            .define("genericError", "Something went wrong!")
 
         FAQ_ERROR = builder.comment("Message sent to Discord if an error ocurrs during FAQ loading")
             .define("faqError", "Bot Error (Contact Bot Operator)")
@@ -39,18 +47,26 @@ object AstralBotTextConfig {
                 The player's name can be accessed via {{name}} and its name with pre- and suffix
                 via {{fullName}}. The message itself is accessed via {{message}}.
             """.trimIndent())
-                .define("playerMessage", "<{{fullName}}> {{message}}")
+                .define(mutableListOf("messages", "minecraft"), "<{{fullName}}> {{message}}")
 
         DISCORD_MESSAGE =
             builder.comment("""Template for how Discord messages are synchronized to Minecraft.
                 The sender is referenced by {{user}}. The optional response is accessed by {{reply}}
             """.trimIndent())
-                .define("discordMessage", "{{user}}{{reply}}:")
+                .define(mutableListOf("messages", "discord", "message"), "{{user}}{{reply}}:")
         DISCORD_REPLY =
             builder.comment("""Template for the {{reply}} part of the discordMessage.
                 The user the message is in reply to is referenced by {{replied}}
             """.trimIndent())
-                .define("discordReply", " replying to {{replied}}:")
+                .define(mutableListOf("messages", "discord", "reply"), " replying to {{replied}}:")
+
+        RELOAD_ERROR =
+            builder.comment("""Template for the error message sent to Discord when reloading fails.
+                The error message itself is accessible with {{error}}
+            """.trimIndent())
+                .define(mutableListOf("reload", "error"), "Something went wrong: {{error}}")
+        RELOAD_SUCCESS = builder.comment("Message sent to Discord after a successful reload")
+            .define(mutableListOf("reload", "success"), "Reloaded commands for guild")
 
         SPEC = builder.build()
     }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -20,9 +20,18 @@ object AstralBotTextConfig {
     val RELOAD_ERROR: ForgeConfigSpec.ConfigValue<String>
     val RELOAD_SUCCESS: ForgeConfigSpec.ConfigValue<String>
 
+    val LINK_NO_MINECRAFT: ForgeConfigSpec.ConfigValue<String>
+    val LINK_MINECRAFT_TAKEN: ForgeConfigSpec.ConfigValue<String>
+    val LINK_DISCORD_TAKEN: ForgeConfigSpec.ConfigValue<String>
+    val LINK_SUCCESSFUL: ForgeConfigSpec.ConfigValue<String>
+    val LINK_ERROR: ForgeConfigSpec.ConfigValue<String>
+
+    val LINK_COMMAND_MESSAGE: ForgeConfigSpec.ConfigValue<String>
+    val LINK_COMMAND_ALREADY_LINKED: ForgeConfigSpec.ConfigValue<String>
+
     init {
         val builder = ForgeConfigSpec.Builder()
-        val whitespaceRegex = Regex("\n[ \t]+");
+        val whitespaceRegex = Regex("\n[ \t]+")
 
         GENERIC_ERROR = builder.comment("Generic error message sent to Discord")
             .define("genericError", "Something went wrong!")
@@ -69,6 +78,49 @@ object AstralBotTextConfig {
                 .define(mutableListOf("reload", "error"), "Something went wrong: {{error}}")
         RELOAD_SUCCESS = builder.comment("Message sent to Discord after a successful reload")
             .define(mutableListOf("reload", "success"), "Reloaded commands for guild")
+
+        LINK_NO_MINECRAFT =
+            builder.comment("""
+                Message for when there's no Minecraft account associated with the given Link code.
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("link", "noMinecraft"), "Couldn't find Minecraft account to link.")
+        LINK_MINECRAFT_TAKEN =
+            builder.comment("""
+                Message for when the Minecraft account is already linked. This should never happen under
+                normal circumstances.
+                The Minecraft username is referenced by {{name}}
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("link", "minecaftTaken"), "Minecraft username {{name}} already linked.")
+        LINK_DISCORD_TAKEN =
+            builder.comment("""
+                Message for when a Discord account is already linked.
+                The Discord user is referenced by {{name}}
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("link", "discordTaken"), "{{name}} already linked.")
+        LINK_SUCCESSFUL =
+            builder.comment("""
+                Message for when linking was successful.
+                The Minecraft usernames can be accessed via {{mc}}. The Discord user via {{dc}}
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("link", "successful"), "Linked {{dc}} to Minecraft username {{mc}}.")
+        LINK_ERROR =
+            builder.comment("""
+                Message for when linking failed for some reason.
+                The error message can be accessed via {{error}}
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("link", "error"), "Failed to link: {{error}}")
+
+        LINK_COMMAND_MESSAGE =
+            builder.comment("""
+                The message sent to a Minecraft user that requested a link code.
+                The code is referenced via {{code}}
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("link", "command", "message"), "Use this code to /link yourself on Discord: {{code}}")
+        LINK_COMMAND_ALREADY_LINKED =
+            builder.comment("""
+                The message sent to a Minecraft user requesting a link code when they're already linked.
+            """.replace(whitespaceRegex, "\n"))
+                .define(mutableListOf("link", "command", "alreadyLinked"), "You're already linked!")
 
         SPEC = builder.build()
     }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -8,6 +8,10 @@ object AstralBotTextConfig {
     val FAQ_ERROR: ForgeConfigSpec.ConfigValue<String>
     val FAQ_NO_REGISTERED: ForgeConfigSpec.ConfigValue<String>
 
+    val TICK_REPORT: ForgeConfigSpec.ConfigValue<String>
+
+    val PLAYER_MESSAGE: ForgeConfigSpec.ConfigValue<String>
+
     init {
         val builder = ForgeConfigSpec.Builder()
 
@@ -16,9 +20,23 @@ object AstralBotTextConfig {
         FAQ_NO_REGISTERED =
             builder.comment(
                 """Message sent to Discord when there is no FAQ for the given id.
-                The placeholder {{id}} may be used to include the requested id""".trimMargin()
+                The placeholder {{id}} may be used to include the requested id""".trimIndent()
             )
                 .define("faqNoRegistered", "No FAQ registered for id: `{{id}}`")
+
+        TICK_REPORT =
+            builder.comment("""Template for the tick report sent to users on the /tps command.
+                the average time per tick in MSPT can be used via {{mspt}} and the TPS calculated
+                from it via {{tps}}
+            """.trimIndent())
+                .define("tickReport", "Average Tick Time: {{mspt}} MSPT (TPS: {{tps}})")
+
+        PLAYER_MESSAGE =
+            builder.comment("""Template for how Minecraft chat messages are sent to Discord.
+                The player's name can be accessed via {{name}} and its name with pre- and suffix
+                via {{fullName}}. The message itself is accessed via {{message}}.
+            """.trimIndent())
+                .define("playerMessage", "<{{fullName}}> {{message}}")
 
         SPEC = builder.build()
     }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -12,6 +12,9 @@ object AstralBotTextConfig {
 
     val PLAYER_MESSAGE: ForgeConfigSpec.ConfigValue<String>
 
+    val DISCORD_MESSAGE: ForgeConfigSpec.ConfigValue<String>
+    val DISCORD_REPLY: ForgeConfigSpec.ConfigValue<String>
+
     init {
         val builder = ForgeConfigSpec.Builder()
 
@@ -37,6 +40,17 @@ object AstralBotTextConfig {
                 via {{fullName}}. The message itself is accessed via {{message}}.
             """.trimIndent())
                 .define("playerMessage", "<{{fullName}}> {{message}}")
+
+        DISCORD_MESSAGE =
+            builder.comment("""Template for how Discord messages are synchronized to Minecraft.
+                The sender is referenced by {{user}}. The optional response is accessed by {{reply}}
+            """.trimIndent())
+                .define("discordMessage", "{{user}}{{reply}}:")
+        DISCORD_REPLY =
+            builder.comment("""Template for the {{reply}} part of the discordMessage.
+                The user the message is in reply to is referenced by {{replied}}
+            """.trimIndent())
+                .define("discordReply", " replying to {{replied}}:")
 
         SPEC = builder.build()
     }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/handlers/FAQHandler.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/handlers/FAQHandler.kt
@@ -2,6 +2,7 @@ package dev.erdragh.astralbot.handlers
 
 import dev.erdragh.astralbot.LOGGER
 import dev.erdragh.astralbot.baseDirectory
+import dev.erdragh.astralbot.config.AstralBotTextConfig
 import java.io.File
 import java.nio.file.StandardWatchEventKinds
 import kotlin.io.path.extension
@@ -67,11 +68,11 @@ object FAQHandler {
     fun getFAQForId(id: String): String {
         if (!faqDirectory.exists() || !faqDirectory.isDirectory) {
             LOGGER.error("FAQ directory not specified as directory: ${faqDirectory.absolutePath}")
-            return "Bot Error (Contact Bot Operator)"
+            return AstralBotTextConfig.FAQ_ERROR.get()
         }
         val faqFiles = faqDirectory.listFiles { file -> file.name == "$id.md" }
         val faqFile = if (faqFiles?.isNotEmpty() == true) faqFiles[0] else null
-        return faqFile?.readText(Charsets.UTF_8) ?: "No FAQ registered for id: `$id`"
+        return faqFile?.readText(Charsets.UTF_8) ?: AstralBotTextConfig.FAQ_NO_REGISTERED.get().replace("{{id}}", id)
     }
 
     /**

--- a/fabric/src/main/kotlin/dev/erdragh/astralbot/fabric/BotMod.kt
+++ b/fabric/src/main/kotlin/dev/erdragh/astralbot/fabric/BotMod.kt
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.config.ModConfig
 object BotMod : ModInitializer {
     override fun onInitialize() {
         ForgeConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.SERVER, AstralBotConfig.SPEC)
-        ForgeConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.SERVER, AstralBotTextConfig.SPEC, "astralbot-text")
+        ForgeConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.SERVER, AstralBotTextConfig.SPEC, "astralbot-text.toml")
 
         ServerLifecycleEvents.SERVER_STARTED.register {
             LOGGER.info("Starting AstralBot on Fabric")

--- a/fabric/src/main/kotlin/dev/erdragh/astralbot/fabric/BotMod.kt
+++ b/fabric/src/main/kotlin/dev/erdragh/astralbot/fabric/BotMod.kt
@@ -3,6 +3,7 @@ package dev.erdragh.astralbot.fabric
 import dev.erdragh.astralbot.*
 import dev.erdragh.astralbot.commands.minecraft.registerMinecraftCommands
 import dev.erdragh.astralbot.config.AstralBotConfig
+import dev.erdragh.astralbot.config.AstralBotTextConfig
 import dev.erdragh.astralbot.handlers.DiscordMessageComponent
 import fuzs.forgeconfigapiport.api.config.v2.ForgeConfigRegistry
 import net.fabricmc.api.ModInitializer
@@ -16,6 +17,7 @@ import net.minecraftforge.fml.config.ModConfig
 object BotMod : ModInitializer {
     override fun onInitialize() {
         ForgeConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.SERVER, AstralBotConfig.SPEC)
+        ForgeConfigRegistry.INSTANCE.register(MODID, ModConfig.Type.SERVER, AstralBotTextConfig.SPEC, "astralbot-text")
 
         ServerLifecycleEvents.SERVER_STARTED.register {
             LOGGER.info("Starting AstralBot on Fabric")

--- a/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
+++ b/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
@@ -24,7 +24,7 @@ import thedarkcolour.kotlinforforge.forge.FORGE_BUS
 object BotMod {
     init {
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, AstralBotConfig.SPEC)
-        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, AstralBotTextConfig.SPEC, "astralbot-text")
+        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, AstralBotTextConfig.SPEC, "astralbot-text.toml")
         FORGE_BUS.addListener(::onServerStart)
         FORGE_BUS.addListener(::onServerStop)
         FORGE_BUS.addListener(::onChatMessage)

--- a/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
+++ b/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
@@ -3,6 +3,7 @@ package dev.erdragh.astralbot.forge
 import dev.erdragh.astralbot.LOGGER
 import dev.erdragh.astralbot.commands.minecraft.registerMinecraftCommands
 import dev.erdragh.astralbot.config.AstralBotConfig
+import dev.erdragh.astralbot.config.AstralBotTextConfig
 import dev.erdragh.astralbot.forge.event.SystemMessageEvent
 import dev.erdragh.astralbot.handlers.DiscordMessageComponent
 import dev.erdragh.astralbot.minecraftHandler
@@ -23,6 +24,7 @@ import thedarkcolour.kotlinforforge.forge.FORGE_BUS
 object BotMod {
     init {
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, AstralBotConfig.SPEC)
+        ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, AstralBotTextConfig.SPEC, "astralbot-text")
         FORGE_BUS.addListener(::onServerStart)
         FORGE_BUS.addListener(::onServerStop)
         FORGE_BUS.addListener(::onChatMessage)


### PR DESCRIPTION
Adds a new config file to AstralBot that contains text templates for various things.

In turn it also refactors the Discord to Minecraft message formatting.