### PR TITLE
Item/Entity/Text Embeds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
 
   dependencies:
     runs-on: ubuntu-latest
+    if: ${{github.ref == 'refs/heads/version/1.20.1' && github.event_name != 'pull_request'}}
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
@@ -76,7 +77,6 @@ jobs:
           distribution: 'temurin'
 
       - name: Build with Gradle and generate dependency Graph
-        if: ${{github.ref == 'refs/heads/version/1.20.1' && github.event_name != 'pull_request'}}
         uses: gradle/gradle-build-action@v2
         with:
           arguments: dependencies

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # Indev
 - Message Embeds to better represent Minecraft messages on Discord
 - Fix `/link` Minecraft command not being registered on Forge
+- Implement Markdown parsing for Discord to Minecraft message sync
+- Implement automatically converting URLs to clickable links in Minecraft chat
+- Replace blocked URLs before sending Minecraft chat to Discord
 
 # 1.2.1
 Allow providing token via config

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Indev
+- Message Embeds to better represent Minecraft messages on Discord
+- Fix `/link` Minecraft command not being registered on Forge
+
 # 1.2.1
 Allow providing token via config
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ subprojects {
     val jdaVersion: String by project
     val exposedVersion: String by project
     val sqliteJDBCVersion: String by project
+    val commonmarkVersion: String by project
 
     // This array gets used at multiple places, so it's easier to
     // just specify all dependencies at once and re-use them. This
@@ -85,7 +86,10 @@ subprojects {
         // Database driver that allows Exposed to communicate with
         // the SQLite database. This will not be in the JAR and needs to be provided
         // otherwise (e.g. https://www.curseforge.com/minecraft/mc-mods/sqlite-jdbc)
-        "org.xerial:sqlite-jdbc:$sqliteJDBCVersion"
+        "org.xerial:sqlite-jdbc:$sqliteJDBCVersion",
+
+        // Markdown parser used for formatting Discord messages in Minecraft
+        "org.commonmark:commonmark:$commonmarkVersion",
     )
 
     dependencies {

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
@@ -117,7 +117,9 @@ object AstralBotConfig {
                         "https://pornhub.com",
                         "https://xhamster.com",
                         "https://xvideos.com",
-                        "https://rule34.xyz"
+                        "https://rule34.xyz",
+                        "https://rule34.xxx",
+                        "https://discord.gg"
                     )
                 )
             ) {

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
@@ -174,7 +174,7 @@ object AstralBotConfig {
         try {
             val parsedURL = URL(url)
             for (blockedURL in URL_BLOCKLIST.get()) {
-                if (parsedURL.host.equals(URL(blockedURL).host)) return false
+                if (parsedURL.host == URL(blockedURL).host) return false
             }
         } catch (e: Exception) {
             LOGGER.warn("URL $url", e)

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
@@ -81,6 +81,12 @@ object AstralBotConfig {
      */
     val ENABLED_COMMANDS: ForgeConfigSpec.ConfigValue<List<String>>
 
+    /**
+     * Enables parsing Discord messages into Minecraft's Chat Components.
+     * This includes making links clickable, etc.
+     */
+    val ENABLE_MARKDOWN_PARSING: ForgeConfigSpec.BooleanValue
+
     init {
         val builder = ForgeConfigSpec.Builder()
 
@@ -150,6 +156,9 @@ object AstralBotConfig {
                 }
                 return@defineList true
             }
+
+        ENABLE_MARKDOWN_PARSING = builder.comment("Parse Discord messages into Minecraft's Chat Components")
+            .define("enableMarkdownParsing", true)
 
         SPEC = builder.build()
     }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotConfig.kt
@@ -87,6 +87,12 @@ object AstralBotConfig {
      */
     val ENABLE_MARKDOWN_PARSING: ForgeConfigSpec.BooleanValue
 
+    /**
+     * Enables converting detected URLs into clickable links, requires
+     * [ENABLE_MARKDOWN_PARSING] to be enabled to do anything
+     */
+    val ENABLE_AUTO_LINKS: ForgeConfigSpec.BooleanValue
+
     init {
         val builder = ForgeConfigSpec.Builder()
 
@@ -158,7 +164,9 @@ object AstralBotConfig {
             }
 
         ENABLE_MARKDOWN_PARSING = builder.comment("Parse Discord messages into Minecraft's Chat Components")
-            .define("enableMarkdownParsing", true)
+            .define(listOf("markdown", "enabled"), true)
+        ENABLE_AUTO_LINKS = builder.comment("Automatically convert detected URLs into clickable links")
+            .define(listOf("markdown", "autoLinks"), true)
 
         SPEC = builder.build()
     }

--- a/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/config/AstralBotTextConfig.kt
@@ -7,6 +7,7 @@ object AstralBotTextConfig {
 
     val GENERIC_ERROR: ForgeConfigSpec.ConfigValue<String>
     val GENERIC_SUCCESS: ForgeConfigSpec.ConfigValue<String>
+    val GENERIC_BLOCKED: ForgeConfigSpec.ConfigValue<String>
 
     val FAQ_ERROR: ForgeConfigSpec.ConfigValue<String>
     val FAQ_NO_REGISTERED: ForgeConfigSpec.ConfigValue<String>
@@ -17,6 +18,7 @@ object AstralBotTextConfig {
 
     val DISCORD_MESSAGE: ForgeConfigSpec.ConfigValue<String>
     val DISCORD_REPLY: ForgeConfigSpec.ConfigValue<String>
+    val DISCORD_EMBEDS: ForgeConfigSpec.ConfigValue<String>
 
     val RELOAD_ERROR: ForgeConfigSpec.ConfigValue<String>
     val RELOAD_SUCCESS: ForgeConfigSpec.ConfigValue<String>
@@ -41,6 +43,8 @@ object AstralBotTextConfig {
             .define("genericError", "Something went wrong!")
         GENERIC_SUCCESS = builder.comment("Generic success message sent to Discord")
             .define("genericSuccess", "Success!")
+        GENERIC_BLOCKED = builder.comment("Generic string that replaces blocked URLs/Links")
+            .define("genericBlocked", "[BLOCKED]")
 
         FAQ_ERROR = builder.comment("Message sent to Discord if an error ocurrs during FAQ loading")
             .define(mutableListOf("faq", "error"), "Bot Error (Contact Bot Operator)")
@@ -76,6 +80,9 @@ object AstralBotTextConfig {
                 The user the message is in reply to is referenced by {{replied}}
             """.replace(whitespaceRegex, "\n"))
                 .define(mutableListOf("messages", "discord", "reply"), " replying to {{replied}}")
+        DISCORD_EMBEDS =
+            builder.comment("Template for the label of embeds of a message.")
+                .define(mutableListOf("messages", "discord", "embeds"), "Embeds:")
 
         RELOAD_ERROR =
             builder.comment("""Template for the error message sent to Discord when reloading fails.

--- a/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
@@ -33,7 +33,8 @@ import kotlin.math.min
  * @author Erdragh
  */
 class MinecraftHandler(private val server: MinecraftServer) : ListenerAdapter() {
-    private val playerNames = HashSet<String>(server.maxPlayers)
+    private val playerNames = HashSet<String>(server.maxPlayers);
+    private val notchPlayer = byName("Notch")?.let { ServerPlayer(this.server, this.server.allLevels.elementAt(0), it) }
 
     companion object {
         private val numberFormat = DecimalFormat("###.##")
@@ -155,7 +156,7 @@ class MinecraftHandler(private val server: MinecraftServer) : ListenerAdapter() 
     private fun formatHoverItems(stack: ItemStack, knownItems: MutableList<ItemStack>): MessageEmbed? {
         if (knownItems.contains(stack)) return null
         knownItems.add(stack)
-        val tooltip = stack.getTooltipLines(null, TooltipFlag.NORMAL).map(::formatComponentToMarkdown)
+        val tooltip = stack.getTooltipLines(notchPlayer, TooltipFlag.NORMAL).map(::formatComponentToMarkdown)
         return EmbedBuilder()
             .setTitle("${tooltip[0]} ${if (stack.count > 1) "(${stack.count})" else ""}")
             .setDescription(tooltip.drop(1).joinToString("\n"))

--- a/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
@@ -18,6 +18,7 @@ import net.minecraft.network.chat.MutableComponent
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.EntityType
+import net.minecraft.world.item.ItemStack
 import java.awt.Color
 import java.text.DecimalFormat
 import java.util.*
@@ -133,6 +134,7 @@ class MinecraftHandler(private val server: MinecraftServer) : ListenerAdapter() 
         }
 
         val formattedEmbeds: MutableList<MessageEmbed> = mutableListOf()
+        val items: MutableList<ItemStack> = mutableListOf()
 
         for (attachment in attachments) {
             attachment.getValue(HoverEvent.Action.SHOW_TEXT)?.let {
@@ -147,10 +149,12 @@ class MinecraftHandler(private val server: MinecraftServer) : ListenerAdapter() 
                 )
             }
             attachment.getValue(HoverEvent.Action.SHOW_ITEM)?.itemStack?.let {
+                if (items.contains(it)) return@let
+                items.add(it)
                 formattedEmbeds.add(
                     EmbedBuilder()
                         .setDescription(it.item.description.string)
-                        .setTitle("${it.displayName.string} ${if (it.count > 0) "(${it.count})" else ""}")
+                        .setTitle("${it.displayName.string} ${if (it.count > 1) "(${it.count})" else ""}")
                         .let { builder: EmbedBuilder ->
                             it.rarity.color.color?.let { color -> builder.setColor(color) }
                             builder

--- a/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
@@ -159,7 +159,11 @@ class MinecraftHandler(private val server: MinecraftServer) : ListenerAdapter() 
         val tooltip = stack.getTooltipLines(notchPlayer, TooltipFlag.NORMAL).map(::formatComponentToMarkdown)
         return EmbedBuilder()
             .setTitle("${tooltip[0]} ${if (stack.count > 1) "(${stack.count})" else ""}")
-            .setDescription(tooltip.drop(1).joinToString("\n"))
+            .setDescription(tooltip.drop(1).let {
+                if (stack.hasCustomHoverName()) {
+                    listOf(stack.item.description.string).plus(it)
+                } else it
+            }.joinToString("\n"))
             .let { builder: EmbedBuilder ->
                 stack.rarity.color.color?.let { color -> builder.setColor(color) }
                 builder

--- a/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/handlers/MinecraftHandler.kt
@@ -214,7 +214,7 @@ class MinecraftHandler(private val server: MinecraftServer) : ListenerAdapter() 
         textChannel?.sendMessage(
             if (player != null)
                 AstralBotTextConfig.PLAYER_MESSAGE.get()
-                    .replace("{{message}}", escape(message.string))
+                    .replace("{{message}}", formatComponentToMarkdown(message))
                     .replace("{{fullName}}", escape(player.displayName.string))
                     .replace("{{name}}", escape(player.name.string))
             else escape(message.string)

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
@@ -172,7 +172,7 @@ class ComponentRenderer : AbstractVisitor(), NodeRenderer {
                 holder.number++
             }
             else -> {
-                throw IllegalStateException("Unknown list holder type: $listHolder")
+                error("Unknown list holder type: $listHolder")
             }
         }
 

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
@@ -203,7 +203,6 @@ class ComponentRenderer : AbstractVisitor(), NodeRenderer {
         currentComponent.append("\n")
         for (prefix in prefixes.asIterable()) {
             currentComponent.append(prefix)
-            println("applying prefix $prefix")
         }
     }
 

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
@@ -42,11 +42,13 @@ class ComponentRenderer : AbstractVisitor(), NodeRenderer {
             BlockQuote::class.java,
             Code::class.java,
             FencedCodeBlock::class.java,
+            IndentedCodeBlock::class.java,
             BulletList::class.java,
             OrderedList::class.java,
             ListItem::class.java,
             SoftLineBreak::class.java,
-            HardLineBreak::class.java
+            HardLineBreak::class.java,
+            ThematicBreak::class.java
         )
     }
 
@@ -141,6 +143,11 @@ class ComponentRenderer : AbstractVisitor(), NodeRenderer {
         append(Component.literal(fencedCodeBlock.literal).withStyle(ChatFormatting.YELLOW))
     }
 
+    override fun visit(indentedCodeBlock: IndentedCodeBlock?) {
+        if (indentedCodeBlock == null) return
+        append(Component.literal(indentedCodeBlock.literal).withStyle(ChatFormatting.YELLOW))
+    }
+
     override fun visit(bulletList: BulletList?) {
         if (bulletList == null) return
         listHolder = BulletListHolder(listHolder, bulletList)
@@ -197,6 +204,13 @@ class ComponentRenderer : AbstractVisitor(), NodeRenderer {
     override fun visit(hardLineBreak: HardLineBreak?) {
         currentComponent.append("  ")
         newline()
+    }
+
+    override fun visit(thematicBreak: ThematicBreak?) {
+        if (thematicBreak == null) return
+        block()
+        append(thematicBreak.literal)
+        block()
     }
 
     private fun newline() {

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
@@ -110,6 +110,11 @@ class ComponentRenderer : AbstractVisitor(), NodeRenderer {
 
         val literal = text.literal
 
+        if (!AstralBotConfig.ENABLE_AUTO_LINKS.get()) {
+            append(literal)
+            return
+        }
+
         val matcher = urlPattern.matcher(text.literal)
         var lastEnd = 0
         for (result in matcher.results()) {

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/ComponentRenderer.kt
@@ -1,0 +1,247 @@
+package dev.erdragh.astralbot.util
+
+import dev.erdragh.astralbot.config.AstralBotConfig
+import dev.erdragh.astralbot.config.AstralBotTextConfig
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.ClickEvent
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.HoverEvent
+import net.minecraft.network.chat.MutableComponent
+import org.commonmark.node.*
+import org.commonmark.renderer.NodeRenderer
+import java.util.Stack
+
+class ComponentRenderer : AbstractVisitor(), NodeRenderer {
+    companion object {
+        private abstract class ListHolder(val parent: ListHolder?)
+
+        private class BulletListHolder(parent: ListHolder?, list: BulletList) : ListHolder(parent) {
+            val marker: String = list.marker
+        }
+
+        private class OrderedListHolder(parent: ListHolder?, list: OrderedList) : ListHolder(parent) {
+            val delimiter: String = list.markerDelimiter
+            var number: Int = list.markerStartNumber
+        }
+    }
+
+    private var currentComponent: MutableComponent = Component.empty()
+    private val prefixes: Stack<Component> = Stack()
+    private var listHolder: ListHolder? = null
+    private var shouldAddBlock: Boolean = false
+
+    override fun getNodeTypes(): MutableSet<Class<out Node>> {
+        return mutableSetOf(
+            Document::class.java,
+            Heading::class.java,
+            Emphasis::class.java,
+            Link::class.java,
+            Paragraph::class.java,
+            StrongEmphasis::class.java,
+            Text::class.java,
+            BlockQuote::class.java,
+            Code::class.java,
+            FencedCodeBlock::class.java,
+            BulletList::class.java,
+            OrderedList::class.java,
+            ListItem::class.java,
+            SoftLineBreak::class.java,
+            HardLineBreak::class.java
+        )
+    }
+
+    private fun childIntoCurrent(component: MutableComponent, action: () -> Unit) {
+        val temp = currentComponent
+        currentComponent = component
+        action()
+        temp.append(currentComponent)
+        currentComponent = temp
+    }
+
+    fun renderToComponent(node: Node?): MutableComponent {
+        this.render(node)
+        return currentComponent
+    }
+
+    override fun render(node: Node?) {
+        node?.accept(this)
+    }
+
+    override fun visit(document: Document?) {
+        visitChildren(document)
+    }
+
+    override fun visit(heading: Heading?) {
+        if (heading == null) return
+
+        block()
+        childIntoCurrent(Component.empty().withStyle(ChatFormatting.BOLD)) {
+            visitChildren(heading)
+        }
+        block()
+    }
+
+    override fun visit(emphasis: Emphasis?) {
+        childIntoCurrent(Component.empty().withStyle(ChatFormatting.ITALIC)) {
+            super.visit(emphasis)
+        }
+    }
+
+    override fun visit(link: Link?) {
+        if (link == null) return
+        this.formatLink(link, link.title, link.destination)
+    }
+
+    override fun visit(paragraph: Paragraph?) {
+        visitChildren(paragraph)
+        block()
+    }
+
+    override fun visit(strongEmphasis: StrongEmphasis?) {
+        childIntoCurrent(Component.empty().withStyle(ChatFormatting.BOLD)) {
+            super.visit(strongEmphasis)
+        }
+    }
+
+    override fun visit(text: Text?) {
+        if (text == null) return
+
+        val literal = text.literal
+
+        val matcher = urlPattern.matcher(text.literal)
+        var lastEnd = 0
+        for (result in matcher.results()) {
+            append(literal.substring(lastEnd..<result.start()))
+            formatLink(null, result.group(), result.group())
+            lastEnd = result.end()
+        }
+        append(literal.substring(lastEnd))
+    }
+
+    override fun visit(blockQuote: BlockQuote?) {
+        prefixes.push(Component.literal("> ").withStyle(ChatFormatting.DARK_GRAY).withStyle { it.withItalic(false) })
+        block()
+        childIntoCurrent(Component.empty().withStyle(ChatFormatting.GRAY, ChatFormatting.ITALIC)) {
+            visitChildren(blockQuote)
+        }
+        prefixes.pop()
+        block()
+    }
+
+    override fun visit(code: Code?) {
+        if (code == null) return
+        append(
+            Component.literal("`${code.literal}`")
+                .withStyle(ChatFormatting.YELLOW)
+        )
+    }
+
+    override fun visit(fencedCodeBlock: FencedCodeBlock?) {
+        if (fencedCodeBlock == null) return
+        append(Component.literal(fencedCodeBlock.literal).withStyle(ChatFormatting.YELLOW))
+    }
+
+    override fun visit(bulletList: BulletList?) {
+        if (bulletList == null) return
+        listHolder = BulletListHolder(listHolder, bulletList)
+        visitChildren(bulletList)
+        listHolder = listHolder!!.parent
+        block()
+    }
+
+    override fun visit(orderedList: OrderedList?) {
+        if (orderedList == null) return
+        listHolder = OrderedListHolder(listHolder, orderedList)
+        visitChildren(orderedList)
+        listHolder = listHolder!!.parent
+        block()
+    }
+
+    override fun visit(listItem: ListItem?) {
+        if (listItem == null) return
+        val markerIndent = listItem.markerIndent
+        val marker: String
+
+        when (listHolder) {
+            is BulletListHolder -> {
+                marker = " ".repeat(markerIndent) + (listHolder!! as BulletListHolder).marker
+            }
+            is OrderedListHolder -> {
+                val holder = listHolder!! as OrderedListHolder
+                marker = " ".repeat(markerIndent) + holder.number + holder.delimiter
+                holder.number++
+            }
+            else -> {
+                throw IllegalStateException("Unknown list holder type: $listHolder")
+            }
+        }
+
+        block()
+
+        val contentIndent = listItem.contentIndent
+        append(marker)
+        append(" ".repeat(contentIndent - marker.length))
+        prefixes.push(Component.literal(" ".repeat(contentIndent)))
+
+        if (listItem.firstChild != null) {
+            // not an empty list
+            visitChildren(listItem)
+        }
+        prefixes.pop()
+    }
+
+    override fun visit(softLineBreak: SoftLineBreak?) {
+        newline()
+    }
+
+    override fun visit(hardLineBreak: HardLineBreak?) {
+        currentComponent.append("  ")
+        newline()
+    }
+
+    private fun newline() {
+        currentComponent.append("\n")
+        for (prefix in prefixes.asIterable()) {
+            currentComponent.append(prefix)
+            println("applying prefix $prefix")
+        }
+    }
+
+    private fun formatLink(node: Node?, title: String?, destination: String) {
+        childIntoCurrent(Component.empty()
+            .withStyle(ChatFormatting.BLUE, ChatFormatting.UNDERLINE)
+            .withStyle {
+                if (AstralBotConfig.urlAllowed(destination)) {
+                    it
+                        .withClickEvent(ClickEvent(ClickEvent.Action.OPEN_URL, destination))
+                        .withHoverEvent(HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(destination)))
+                } else {
+                    it
+                        .withColor(ChatFormatting.RED)
+                        .withHoverEvent(HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(AstralBotTextConfig.GENERIC_BLOCKED.get())))
+                }
+            }
+        ) {
+            node?.let(::visitChildren)
+            if (title != null) {
+                append(title)
+            }
+        }
+    }
+
+    private fun block() {
+        this.shouldAddBlock = true
+    }
+
+    private fun append(component: Component) {
+        if (this.shouldAddBlock) {
+            this.shouldAddBlock = false
+            newline()
+        }
+        this.currentComponent.append(component)
+    }
+
+    private fun append(literal: String) {
+        append(Component.literal(literal))
+    }
+}

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/MessageFormatting.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/MessageFormatting.kt
@@ -26,6 +26,8 @@ val urlPattern: Pattern = Pattern.compile(
 )
 
 fun formatMarkdownToComponent(md: String): MutableComponent {
+    if (!AstralBotConfig.ENABLE_MARKDOWN_PARSING.get()) return Component.literal(md)
+
     val parser = Parser.builder().build()
     val parsed = parser.parse(md)
     val renderer = ComponentRenderer()

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/MessageFormatting.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/MessageFormatting.kt
@@ -1,0 +1,110 @@
+package dev.erdragh.astralbot.util
+
+import dev.erdragh.astralbot.config.AstralBotConfig
+import dev.erdragh.astralbot.config.AstralBotTextConfig
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.minecraft.network.chat.ClickEvent
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.HoverEvent
+import net.minecraft.network.chat.MutableComponent
+import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.player.Player
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.TooltipFlag
+import org.commonmark.parser.Parser
+import java.awt.Color
+import java.util.regex.Pattern
+
+// Pattern for recognizing a URL, based off RFC 3986
+// Source: https://stackoverflow.com/questions/5713558/detect-and-extract-url-from-a-string
+val urlPattern: Pattern = Pattern.compile(
+    "(?:^|[\\W])((ht|f)tp(s?):\\/\\/|www\\.)"
+            + "(([\\w\\-]+\\.){1,}?([\\w\\-.~]+\\/?)*"
+            + "[\\p{Alnum}.,%_=?&#\\-+()\\[\\]\\*$~@!:/{};']*)",
+    Pattern.CASE_INSENSITIVE or Pattern.MULTILINE or Pattern.DOTALL
+)
+
+fun formatMarkdownToComponent(md: String): MutableComponent {
+    val parser = Parser.builder().build()
+    val parsed = parser.parse(md)
+    val renderer = ComponentRenderer()
+
+    return renderer.renderToComponent(parsed)
+}
+
+fun formatComponentToMarkdown(comp: Component): String {
+    return comp.toFlatList()
+        .map {
+            var formatted = it.string
+
+            if (it.style.isBold) {
+                formatted = "**$formatted**"
+            }
+            if (it.style.isItalic) {
+                formatted = "_${formatted}_"
+            }
+            it.style.clickEvent?.let { clickEvent ->
+                if (clickEvent.action == ClickEvent.Action.OPEN_URL) {
+                    formatted = "[$formatted](${clickEvent.value})"
+                }
+            }
+
+            val matcher = urlPattern.matcher(formatted)
+            val replaced = matcher.replaceAll { match ->
+                val group = match.group()
+                if (AstralBotConfig.urlAllowed(group)) {
+                    return@replaceAll group
+                } else {
+                    return@replaceAll AstralBotTextConfig.GENERIC_BLOCKED.get()
+                }
+            }
+            formatted = replaced
+
+            return@map formatted
+        }
+        .joinToString("")
+}
+
+fun formatHoverText(text: Component): MessageEmbed {
+    return EmbedBuilder()
+        .setDescription(text.string)
+        .let { builder: EmbedBuilder ->
+            text.style.color?.value?.let { color -> builder.setColor(color) }
+            builder
+        }
+        .build()
+}
+
+fun formatHoverItems(stack: ItemStack, knownItems: MutableList<ItemStack>, player: Player?): MessageEmbed? {
+    if (knownItems.contains(stack)) return null
+    knownItems.add(stack)
+    val tooltip = stack.getTooltipLines(player, TooltipFlag.NORMAL).map(::formatComponentToMarkdown)
+    return EmbedBuilder()
+        .setTitle("${tooltip[0]} ${if (stack.count > 1) "(${stack.count})" else ""}")
+        .setDescription(tooltip.drop(1).let {
+            if (stack.hasCustomHoverName()) {
+                listOf(stack.item.description.string).plus(it)
+            } else it
+        }.joinToString("\n"))
+        .let { builder: EmbedBuilder ->
+            stack.rarity.color.color?.let { color -> builder.setColor(color) }
+            builder
+        }
+        .build()
+}
+
+fun formatHoverEntity(entity: HoverEvent.EntityTooltipInfo): MessageEmbed? {
+    if (entity.type == EntityType.PLAYER) return null
+    return EmbedBuilder()
+        .setTitle(entity.name?.string)
+        .setDescription(entity.type.description.string)
+        .let { builder: EmbedBuilder ->
+            val mobCategory = entity.type.category
+            if (mobCategory.isFriendly) {
+                builder.setColor(Color.GREEN)
+            }
+            builder
+        }
+        .build()
+}

--- a/common/src/main/kotlin/dev/erdragh/astralbot/util/MessageFormatting.kt
+++ b/common/src/main/kotlin/dev/erdragh/astralbot/util/MessageFormatting.kt
@@ -55,10 +55,10 @@ fun formatComponentToMarkdown(comp: Component): String {
             val matcher = urlPattern.matcher(formatted)
             val replaced = matcher.replaceAll { match ->
                 val group = match.group()
-                if (AstralBotConfig.urlAllowed(group)) {
-                    return@replaceAll group
+                return@replaceAll if (AstralBotConfig.urlAllowed(group)) {
+                    group
                 } else {
-                    return@replaceAll AstralBotTextConfig.GENERIC_BLOCKED.get()
+                    AstralBotTextConfig.GENERIC_BLOCKED.get()
                 }
             }
             formatted = replaced

--- a/common/src/main/kotlin/module-info.java
+++ b/common/src/main/kotlin/module-info.java
@@ -14,6 +14,8 @@ module Minecraft.astralbot.common.main {
 
   // For Discord Interaction
   requires net.dv8tion.jda;
+  // For message parsing
+  requires org.commonmark;
 
   // For Minecraft itself
   requires authlib;

--- a/fabric/src/main/kotlin/dev/erdragh/astralbot/fabric/BotMod.kt
+++ b/fabric/src/main/kotlin/dev/erdragh/astralbot/fabric/BotMod.kt
@@ -29,11 +29,11 @@ object BotMod : ModInitializer {
         }
 
         ServerMessageEvents.CHAT_MESSAGE.register { message, player, _ ->
-            minecraftHandler?.sendChatToDiscord(player, message.signedContent())
+            minecraftHandler?.sendChatToDiscord(player, message.decoratedContent())
         }
         ServerMessageEvents.GAME_MESSAGE.register { _, message, _ ->
             if (message !is DiscordMessageComponent) {
-                minecraftHandler?.sendChatToDiscord(null as ServerPlayer?, message.string)
+                minecraftHandler?.sendChatToDiscord(null as ServerPlayer?, message)
             }
         }
 

--- a/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
+++ b/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
@@ -29,6 +29,7 @@ object BotMod {
         FORGE_BUS.addListener(::onServerStop)
         FORGE_BUS.addListener(::onChatMessage)
         FORGE_BUS.addListener(::onSystemMessage)
+        FORGE_BUS.addListener(::onCommandRegistration)
 
         FORGE_BUS.addListener(::onPlayerJoin)
         FORGE_BUS.addListener(::onPlayerLeave)

--- a/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
+++ b/forge/src/main/kotlin/dev/erdragh/astralbot/forge/BotMod.kt
@@ -44,12 +44,12 @@ object BotMod {
     }
 
     private fun onChatMessage(event: ServerChatEvent) {
-        minecraftHandler?.sendChatToDiscord(event.player, event.message.string)
+        minecraftHandler?.sendChatToDiscord(event.player, event.message)
     }
 
     private fun onSystemMessage(event: SystemMessageEvent) {
         if (event.message !is DiscordMessageComponent) {
-            minecraftHandler?.sendChatToDiscord(null as ServerPlayer?, event.message.string)
+            minecraftHandler?.sendChatToDiscord(null as ServerPlayer?, event.message)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,11 @@ parchmentVersion=2023.09.03
 forgeConfigAPIVersion=8.0.0
 
 # Discord Interactions
-jdaVersion=5.0.0-beta.22
+jdaVersion=5.0.0-beta.23
 
 # Database Interactions
 exposedVersion=0.49.0
 sqliteJDBCVersion=3.44.1.0
+
+# Message parsing
+commonmarkVersion=0.22.0


### PR DESCRIPTION
Implements:
- Item embeds if a message has a `Component` with a `SHOW_ITEM` hover action
- Entity embeds if a `Component` has a `SHOW_ENTITY` hover action
- Text embeds if a `Component` has a `SHOW_TEXT` hover action

Embed colors are decided by:
- Item rarity
- Text embed `Component` color
- Green if entity is passive/friendly

This will also implement:
- [x] #20 (Allowing blocking malicious links in Minecraft messages)
- [x] #19 (Allowing links sent into Discord chat work as links in the Game)